### PR TITLE
Issue 19: Add count on badges

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,6 @@ build-iPhoneSimulator/
 
 # unless supporting rvm < 1.11.0 or doing something fancy, ignore this:
 .rvmrc
+
+# byebug debugger history
+.byebug_history

--- a/Gemfile
+++ b/Gemfile
@@ -7,4 +7,5 @@ source 'https://rubygems.org' do
   gem 'sinatra'
   gem 'rake'
   gem 'test-unit'
+  gem 'byebug', require: false
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,6 +3,7 @@ GEM
   specs:
     addressable (2.5.2)
       public_suffix (>= 2.0.2, < 4.0)
+    byebug (9.1.0)
     concurrent-ruby (1.0.5)
     erubis (2.7.0)
     faraday (0.13.1)
@@ -33,9 +34,11 @@ GEM
     tilt (2.0.8)
 
 PLATFORMS
+  ruby
   x64-mingw32
 
 DEPENDENCIES
+  byebug!
   concurrent-ruby!
   erubis!
   faraday-http-cache!

--- a/lib/badge.rb
+++ b/lib/badge.rb
@@ -11,13 +11,16 @@ class Badge
 
   def earned_by?(player)
     # Return false if no evaluation predicate has been provided
-    return false if !@block || @block.call(player) == false
-    @block.call(player) == true || @block.call(player) > 0
+    return false if !@block
+    result = @block.call(player)
+    result == false ? false : result == true || result > 0
   end
 
   def times_earned_by(player)
     # Return 0 if no evaluation predicate has been provided
-    return 0 if !@block || @block.call(player) == false
-    @block.call(player) == true ? 1 : @block.call(player)
+    return 0 if !@block
+    result = @block.call(player)
+    return 0 if result == false
+    result == true ? 1 : result
   end
 end

--- a/lib/badge.rb
+++ b/lib/badge.rb
@@ -1,0 +1,23 @@
+# Class reprensenting a badge a player can earn
+class Badge
+  attr_reader :short, :title, :description
+
+  def initialize(short, title, description, &block)
+    @short = short
+    @title = title
+    @description = description
+    @block = block
+  end
+
+  def earned_by?(player)
+    # Return false if no evaluation predicate has been provided
+    return false if !@block || @block.call(player) == false
+    @block.call(player) == true || @block.call(player) > 0
+  end
+
+  def times_earned_by(player)
+    # Return 0 if no evaluation predicate has been provided
+    return 0 if !@block || @block.call(player) == false
+    @block.call(player) == true ? 1 : @block.call(player)
+  end
+end

--- a/lib/leaderboard.rb
+++ b/lib/leaderboard.rb
@@ -24,7 +24,8 @@ class Badge
 
   def earned_by?(player)
     # Return false if no evaluation predicate has been provided
-    @block && @block.call(player) || false
+    return false if !@block || @block.call(player) == false
+    @block.call(player) == true || @block.call(player) > 0
   end
 end
 

--- a/lib/leaderboard.rb
+++ b/lib/leaderboard.rb
@@ -3,8 +3,8 @@ require 'faraday-http-cache'
 require 'json'
 require 'octokit'
 require 'open-uri'
-# require_relative 'badge'
-# require_relative 'member'
+require_relative 'badge'
+require_relative 'member'
 
 include Concurrent
 BASE_API_URL = 'https://api.github.com'.freeze

--- a/lib/leaderboard.rb
+++ b/lib/leaderboard.rb
@@ -3,6 +3,7 @@ require 'faraday-http-cache'
 require 'json'
 require 'octokit'
 require 'open-uri'
+# require_relative 'member'
 
 include Concurrent
 BASE_API_URL = 'https://api.github.com'.freeze
@@ -121,99 +122,5 @@ class Leaderboard
     @github.user(username)
   rescue Octokit::NotFound
     nil
-  end
-end
-
-# A contest member from the participant list in landing page
-class Member
-  attr_reader :username, :avatar, :profile, :contributions, :invalids, :issues
-
-  # Construct a user using the data fetched from GitHub
-  def initialize(github_user, contributions)
-    @username = github_user.login
-    @avatar = github_user.avatar_url
-    @profile = github_user.html_url
-    @invalids = []
-    @contributions = []
-    @issues = []
-    add_contributions(contributions)
-  end
-
-  # Check if the user has completed the challenge
-  def challenge_complete?
-    contributions.size >= 4
-  end
-
-  # Returns the completion percentage
-  def challenge_completion
-    [100, ((contributions_count.to_f / 4.0) * 100).to_i].min
-  end
-
-  # Count the number of valid contributions
-  def contributions_count
-    contributions.size
-  end
-
-  def contributed_to_snake
-    contributions.count { |c| c.repository_url == SNAKE_URL }
-  end
-
-  def contributed_to_leaderboard
-    contributions.count { |c| c.repository_url == LEADERBOARD_URL }
-  end
-
-  def ten_contributions?
-    contributions.size >= 10
-  end
-
-  def contributed_out_of_org
-    contributions.count do |c|
-      !c.repository_url.start_with?(ORG_REPOS_URL) &&
-        !c.repository_url.start_with?("#{BASE_REPOS_URL}/#{@username}")
-    end
-  end
-
-  def contribution_with_100_words
-    contributions.count { |c| c.body.split(' ').count >= 100 }
-  end
-
-  def contribution_with_no_word
-    contributions.count { |c| c.body.strip.empty? }
-  end
-
-  def contribution_to_own_repos
-    contributions.count do |c|
-      c.repository_url.start_with? "#{BASE_REPOS_URL}/#{@username}"
-    end
-  end
-
-  def invalid_contribs
-    invalids.size
-  end
-
-  def badges
-    BADGES.select { |b| b.earned_by?(self) }
-  end
-
-  def to_json(*_opts)
-    {
-      username: @username,
-      avatar: @avatar,
-      profile: @profile
-    }.to_json
-  end
-
-  private
-
-  def add_contributions(contributions)
-    contributions.each do |contrib|
-      if !contrib.pull_request
-        @issues << contrib
-      elsif contrib.labels.any? { |l| l.name == 'invalid' }
-        @invalids << contrib
-      else
-        @contributions << contrib
-      end
-    end
   end
 end

--- a/lib/leaderboard.rb
+++ b/lib/leaderboard.rb
@@ -3,6 +3,7 @@ require 'faraday-http-cache'
 require 'json'
 require 'octokit'
 require 'open-uri'
+# require_relative 'badge'
 # require_relative 'member'
 
 include Concurrent
@@ -11,30 +12,6 @@ BASE_REPOS_URL = "#{BASE_API_URL}/repos".freeze
 ORG_REPOS_URL = "#{BASE_REPOS_URL}/ourtigarage".freeze
 SNAKE_URL = "#{ORG_REPOS_URL}/web-snake".freeze
 LEADERBOARD_URL = "#{ORG_REPOS_URL}/hacktoberfest-leaderboard".freeze
-
-# Class reprensenting a badge a player can earn
-class Badge
-  attr_reader :short, :title, :description
-
-  def initialize(short, title, description, &block)
-    @short = short
-    @title = title
-    @description = description
-    @block = block
-  end
-
-  def earned_by?(player)
-    # Return false if no evaluation predicate has been provided
-    return false if !@block || @block.call(player) == false
-    @block.call(player) == true || @block.call(player) > 0
-  end
-
-  def times_earned_by(player)
-    # Return 0 if no evaluation predicate has been provided
-    return 0 if !@block || @block.call(player) == false
-    @block.call(player) == true ? 1 : @block.call(player)
-  end
-end
 
 # This is the list of all badges that can be earned
 # The block that define the badge's challenge should return either an integer or a boolean

--- a/lib/leaderboard.rb
+++ b/lib/leaderboard.rb
@@ -27,6 +27,12 @@ class Badge
     return false if !@block || @block.call(player) == false
     @block.call(player) == true || @block.call(player) > 0
   end
+
+  def times_earned_by(player)
+    # Return 0 if no evaluation predicate has been provided
+    return 0 if !@block || @block.call(player) == false
+    @block.call(player) == true ? 1 : @block.call(player)
+  end
 end
 
 # This is the list of all badges that can be earned

--- a/lib/leaderboard.rb
+++ b/lib/leaderboard.rb
@@ -29,16 +29,18 @@ class Badge
   end
 end
 
+# This is the list of all badges that can be earned
+# The block that define the badge's challenge should return either an integer or a boolean
 BADGES = [
   Badge.new('hacktoberfest', 'Hacktoberfest completed', 'Completed the hacktoberfest challenge by submitting 4 pull requests', &:challenge_complete?),
-  Badge.new('snake', 'The snake charmer', 'Submitted 1 Pull Request to the <a href="https://ourtigarage.github.io/web-snake/">snake game</a>\'s code repository', &:contributed_to_snake?),
-  Badge.new('leaderboard', 'The leaderboard contributor', 'Submitted 1 Pull Request to this leaderboard\'s code repository', &:contributed_to_leaderboard?),
+  Badge.new('snake', 'The snake charmer', 'Submitted 1 Pull Request to the <a href="https://ourtigarage.github.io/web-snake/">snake game</a>\'s code repository', &:contributed_to_snake),
+  Badge.new('leaderboard', 'The leaderboard contributor', 'Submitted 1 Pull Request to this leaderboard\'s code repository', &:contributed_to_leaderboard),
   Badge.new('10-contributions', 'The Pull Request champion', 'Submitted more than 10 Pull requests', &:ten_contributions?),
-  Badge.new('adventure', 'The adventurer', 'Submitted 1 Pull Request to a repository he does not own, out of <a href="https://github.com/ourtigarage">ourtigarage</a> organisation', &:contributed_out_of_org?),
-  Badge.new('novelist', 'The novelist', 'Wrote more than 100 words in a Pull Request\'s description', &:contribution_with_100_words?),
-  Badge.new('taciturn', 'The taciturn', 'Submitted a Pull Request with no description', &:contribution_with_no_word?),
-  Badge.new('pirate', 'The mighty pirate', 'A lawless pirate who submitted Pull Requests to his own repositories. Cheater...', &:contribution_to_own_repos?),
-  Badge.new('crap', 'The smelly code', 'Has a Pull Request marked as invalid. Probably some bad smelling code', &:invalid_contribs?)
+  Badge.new('adventure', 'The adventurer', 'Submitted 1 Pull Request to a repository he does not own, out of <a href="https://github.com/ourtigarage">ourtigarage</a> organisation', &:contributed_out_of_org),
+  Badge.new('novelist', 'The novelist', 'Wrote more than 100 words in a Pull Request\'s description', &:contribution_with_100_words),
+  Badge.new('taciturn', 'The taciturn', 'Submitted a Pull Request with no description', &:contribution_with_no_word),
+  Badge.new('pirate', 'The mighty pirate', 'A lawless pirate who submitted Pull Requests to his own repositories. Cheater...', &:contribution_to_own_repos),
+  Badge.new('crap', 'The smelly code', 'Has a Pull Request marked as invalid. Probably some bad smelling code', &:invalid_contribs)
 ].freeze
 
 # The leaderboard root class, where the magic happens
@@ -146,41 +148,41 @@ class Member
     contributions.size
   end
 
-  def contributed_to_snake?
-    contributions.any? { |c| c.repository_url == SNAKE_URL }
+  def contributed_to_snake
+    contributions.count { |c| c.repository_url == SNAKE_URL }
   end
 
-  def contributed_to_leaderboard?
-    contributions.any? { |c| c.repository_url == LEADERBOARD_URL }
+  def contributed_to_leaderboard
+    contributions.count { |c| c.repository_url == LEADERBOARD_URL }
   end
 
   def ten_contributions?
     contributions.size >= 10
   end
 
-  def contributed_out_of_org?
-    contributions.any? do |c|
+  def contributed_out_of_org
+    contributions.count do |c|
       !c.repository_url.start_with?(ORG_REPOS_URL) &&
         !c.repository_url.start_with?("#{BASE_REPOS_URL}/#{@username}")
     end
   end
 
-  def contribution_with_100_words?
-    contributions.any? { |c| c.body.split(' ').count >= 100 }
+  def contribution_with_100_words
+    contributions.count { |c| c.body.split(' ').count >= 100 }
   end
 
-  def contribution_with_no_word?
-    contributions.any? { |c| c.body.strip.empty? }
+  def contribution_with_no_word
+    contributions.count { |c| c.body.strip.empty? }
   end
 
-  def contribution_to_own_repos?
-    contributions.any? do |c|
+  def contribution_to_own_repos
+    contributions.count do |c|
       c.repository_url.start_with? "#{BASE_REPOS_URL}/#{@username}"
     end
   end
 
-  def invalid_contribs?
-    !invalids.empty?
+  def invalid_contribs
+    invalids.size
   end
 
   def badges

--- a/lib/member.rb
+++ b/lib/member.rb
@@ -1,0 +1,93 @@
+# A contest member from the participant list in landing page
+class Member
+  attr_reader :username, :avatar, :profile, :contributions, :invalids, :issues
+
+  # Construct a user using the data fetched from GitHub
+  def initialize(github_user, contributions)
+    @username = github_user.login
+    @avatar = github_user.avatar_url
+    @profile = github_user.html_url
+    @invalids = []
+    @contributions = []
+    @issues = []
+    add_contributions(contributions)
+  end
+
+  # Check if the user has completed the challenge
+  def challenge_complete?
+    contributions.size >= 4
+  end
+
+  # Returns the completion percentage
+  def challenge_completion
+    [100, ((contributions_count.to_f / 4.0) * 100).to_i].min
+  end
+
+  # Count the number of valid contributions
+  def contributions_count
+    contributions.size
+  end
+
+  def contributed_to_snake
+    contributions.count { |c| c.repository_url == SNAKE_URL }
+  end
+
+  def contributed_to_leaderboard
+    contributions.count { |c| c.repository_url == LEADERBOARD_URL }
+  end
+
+  def ten_contributions?
+    contributions.size >= 10
+  end
+
+  def contributed_out_of_org
+    contributions.count do |c|
+      !c.repository_url.start_with?(ORG_REPOS_URL) &&
+        !c.repository_url.start_with?("#{BASE_REPOS_URL}/#{@username}")
+    end
+  end
+
+  def contribution_with_100_words
+    contributions.count { |c| c.body.split(' ').count >= 100 }
+  end
+
+  def contribution_with_no_word
+    contributions.count { |c| c.body.strip.empty? }
+  end
+
+  def contribution_to_own_repos
+    contributions.count do |c|
+      c.repository_url.start_with? "#{BASE_REPOS_URL}/#{@username}"
+    end
+  end
+
+  def invalid_contribs
+    invalids.size
+  end
+
+  def badges
+    BADGES.select { |b| b.earned_by?(self) }
+  end
+
+  def to_json(*_opts)
+    {
+      username: @username,
+      avatar: @avatar,
+      profile: @profile
+    }.to_json
+  end
+
+  private
+
+  def add_contributions(contributions)
+    contributions.each do |contrib|
+      if !contrib.pull_request
+        @issues << contrib
+      elsif contrib.labels.any? { |l| l.name == 'invalid' }
+        @invalids << contrib
+      else
+        @contributions << contrib
+      end
+    end
+  end
+end

--- a/server.rb
+++ b/server.rb
@@ -1,8 +1,6 @@
 require 'erubis'
 require 'json'
 require 'sinatra'
-require_relative 'lib/badge'
-require_relative 'lib/member'
 require_relative 'lib/leaderboard'
 
 if ENV['APP_ENV'] == 'development'

--- a/server.rb
+++ b/server.rb
@@ -1,6 +1,7 @@
 require 'erubis'
 require 'json'
 require 'sinatra'
+require_relative 'lib/member'
 require_relative 'lib/leaderboard'
 
 if ENV['APP_ENV'] == 'development'

--- a/server.rb
+++ b/server.rb
@@ -1,6 +1,7 @@
 require 'erubis'
 require 'json'
 require 'sinatra'
+require_relative 'lib/badge'
 require_relative 'lib/member'
 require_relative 'lib/leaderboard'
 

--- a/server.rb
+++ b/server.rb
@@ -3,6 +3,10 @@ require 'json'
 require 'sinatra'
 require_relative 'lib/leaderboard'
 
+if ENV['APP_ENV'] == 'development'
+  require 'byebug'
+end
+
 # URL to the participant list file. Can be local or remote
 PARTICIPANTS_FILE = 'https://raw.githubusercontent.com/ourtigarage/hacktoberfest-summit/master/participants.md'.freeze
 # The date for the event in the format github date

--- a/tests/tests.rb
+++ b/tests/tests.rb
@@ -1,4 +1,6 @@
 require 'test/unit'
+require_relative '../lib/badge'
+require_relative '../lib/member'
 require_relative '../lib/leaderboard'
 
 # Test case for leaderboard

--- a/tests/tests.rb
+++ b/tests/tests.rb
@@ -1,6 +1,4 @@
 require 'test/unit'
-require_relative '../lib/badge'
-require_relative '../lib/member'
 require_relative '../lib/leaderboard'
 
 # Test case for leaderboard

--- a/views/index.erb
+++ b/views/index.erb
@@ -40,7 +40,7 @@
 									<!-- List of badges earned -->
 									<% for badge in member.badges %>
 										<div class="popover popover-top">
-											<figure class="avatar avatar-xl">
+											<figure class="avatar avatar-xl badge" data-badge="<%= badge.times_earned_by(member) %>">
 												<img src="img/badges/<%=badge.short%>.png" alt="<%=badge.short%>">
 											</figure>
 											<div class="popover-container">


### PR DESCRIPTION
This PR should close ourtigarage/hacktoberfest-leaderboard#19.
The PR updates the code of block methods passed to badge objects to count how many times the badge is earned or (as in the case of Hacktoberfest completed badge) just to check if challenge is completed.
1) To make this work properly the earned_by? method in Badge class has been updated to accept either an integer or a boolean argument.
2) A new method times_earned_by(player) has been added to Badge class, this method returns the count of times a badge is earned by a player.
3) The count was also added in the leaderboard view as data-badge attribute to the badge icon.

The PR also add a minor refactor to the code structure creating a file for each of Member and Badge classes (to make code more readable) and adding the byebug gem if env is set as development (to simplify code debugging)