### PR TITLE
Fixed default objective

### DIFF
--- a/server.rb
+++ b/server.rb
@@ -12,7 +12,7 @@ PARTICIPANTS_FILE = (ENV['PARTICIPANTS_FILE'] || 'https://raw.githubusercontent.
 # Default to ">=2005", since gti was released in 2005
 EVENT_DATE = (ENV['EVENT_DATE'] || '>=2005').freeze
 
-Member.objective = (ENV['OBJECTIVE'].to_i || 5).freeze
+Member.objective = (ENV['OBJECTIVE'] || '5').to_i.freeze
 
 # Initialize the leaderboard
 leaderboard = Leaderboard.new EVENT_DATE, PARTICIPANTS_FILE


### PR DESCRIPTION
When environment variable "OBJECTIVE" is missing, default value cannot be used and cause a crash. This PR fixes this