### PR TITLE
Update to consider new hacktoberfest rules

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -55,4 +55,4 @@ RUBY VERSION
    ruby 2.5.1p57
 
 BUNDLED WITH
-   1.16.5
+   2.1.4

--- a/lib/leaderboard.rb
+++ b/lib/leaderboard.rb
@@ -85,7 +85,7 @@ class Leaderboard
     @github.search_issues(query_filter)
            .items
            .each_with_object({}) do |e, acc|
-             (acc[e.user.login] ||= [e.user, []])[1] << e
+             (acc[e.user.login] ||= [e.user, [], @github])[1] << e
            end
   end
 
@@ -99,7 +99,7 @@ class Leaderboard
 
   def add_missing_users(usernames, data)
     query_missing_users_data(usernames, data)
-      .each_with_object(data) { |e, acc| acc[e.login] ||= [e, []] }
+      .each_with_object(data) { |e, acc| acc[e.login] ||= [e, [], @github] }
   end
 
   def members_data(usernames)

--- a/server.rb
+++ b/server.rb
@@ -14,7 +14,7 @@ PARTICIPANTS_FILE = (ENV['PARTICIPANTS_FILE'] || 'https://raw.githubusercontent.
 # Default to ">=2005", since git was released in 2005
 EVENT_DATE = (ENV['EVENT_DATE'] || '>=2005').freeze
 
-Member.objective = (ENV['OBJECTIVE'] || '5').to_i.freeze
+Member.objective = (ENV['OBJECTIVE'] || '4').to_i.freeze
 
 # Initialize the leaderboard
 leaderboard = Leaderboard.new EVENT_DATE, PARTICIPANTS_FILE


### PR DESCRIPTION
Hacktoberfest 2020 edition introduced new rules to avoid spams.

> Maintainers can opt-in to participate by classifying their projects with the **hacktoberfest** topic.
> 
> Your pull requests will count toward your participation if they are in a repository with the **hacktoberfest** topic and once they have been merged, approved by a maintainer or labelled as **hacktoberfest-accepted**.
> 
> Additionally, any pull request with the **hacktoberfest-accepted** label, submitted to any public GitHub repository, with or without the hacktoberfest topic, will be considered valid for Hacktoberfest.
> All valid pull requests **prior to Oct 3** (when these rules were introduced) will be honored and counted toward completion of Hacktoberfest.

This Pull Request add filtering based on those rules